### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/color/package.json
+++ b/packages/color/package.json
@@ -8,6 +8,11 @@
 		"module": "dist/esm/index.js",
 		"types": "dist/types/index.d.ts"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/thematic.git",
+		"directory": "packages/color"
+	},
 	"scripts": {
 		"clean": "essex clean",
 		"build": "essex build",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,11 @@
 		"module": "dist/esm/index.js",
 		"types": "dist/types/index.d.ts"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/thematic.git",
+		"directory": "packages/core"
+	},
 	"scripts": {
 		"clean": "essex clean",
 		"build": "run-s build_lib assets",

--- a/packages/d3/package.json
+++ b/packages/d3/package.json
@@ -8,6 +8,11 @@
 		"module": "dist/esm/index.js",
 		"types": "dist/types/index.d.ts"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/thematic.git",
+		"directory": "packages/d3"
+	},
 	"scripts": {
 		"clean": "essex clean",
 		"build": "essex build",

--- a/packages/fluent/package.json
+++ b/packages/fluent/package.json
@@ -8,6 +8,11 @@
 		"module": "dist/esm/index.js",
 		"types": "dist/types/index.d.ts"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/thematic.git",
+		"directory": "packages/fluent"
+	},
 	"scripts": {
 		"clean": "essex clean",
 		"build": "essex build",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -8,6 +8,11 @@
 		"module": "dist/esm/index.js",
 		"types": "dist/types/index.d.ts"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/thematic.git",
+		"directory": "packages/react"
+	},
 	"scripts": {
 		"clean": "essex clean",
 		"build": "essex build",

--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -8,6 +8,11 @@
 		"module": "dist/esm/index.js",
 		"types": "dist/types/index.d.ts"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/thematic.git",
+		"directory": "packages/vega"
+	},
 	"scripts": {
 		"clean": "essex clean",
 		"build": "essex build",

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -11,6 +11,11 @@
 		"bundle": "essex bundle",
 		"clean": "essex clean build"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/thematic.git",
+		"directory": "packages/webapp"
+	},
 	"dependencies": {
 		"@essex/webpack-config": "^15.0.3",
 		"@fluentui/font-icons-mdl2": "^8.1.0",


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@v-rr](https://github.com/v-rr), [@v-jiepeng](https://github.com/v-jiepeng), [@v-zhzhou](https://github.com/v-zhzhou) and [@v-gjy](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @thematic/color
* @thematic/core
* @thematic/d3
* @thematic/fluent
* @thematic/react
* @thematic/vega
* @thematic/webapp