### PR TITLE
Dark mode improvements

### DIFF
--- a/.yarn/versions/58e0b833.yml
+++ b/.yarn/versions/58e0b833.yml
@@ -1,0 +1,7 @@
+releases:
+  "@thematic/core": minor
+  "@thematic/d3": patch
+  "@thematic/fluent": minor
+  "@thematic/react": minor
+  "@thematic/vega": patch
+  "@thematic/webapp": patch

--- a/packages/core/docs/core.api.md
+++ b/packages/core/docs/core.api.md
@@ -642,14 +642,14 @@ export interface Theme {
     colorBlindness: (mode: ColorBlindnessMode) => Theme;
     // (undocumented)
     config: ThemeConfig;
-    dark: () => Theme;
+    // (undocumented)
+    dark: boolean;
     // (undocumented)
     definition: ThemeDefinition;
     // (undocumented)
     flow: MarkFunction<Flow>;
     // (undocumented)
     gridLines: ChromeFunction<GridLines>;
-    light: () => Theme;
     // (undocumented)
     line: MarkFunction<Line>;
     // (undocumented)
@@ -676,8 +676,10 @@ export interface Theme {
     spec: ThemeSpec;
     // (undocumented)
     text: MarkFunction<Text>;
+    toDark: () => Theme;
     // (undocumented)
     toJSON(config?: ExportConfig): ThemeSpec;
+    toLight: () => Theme;
     // (undocumented)
     tooltip: ChromeFunction<Tooltip>;
     transform: (transformer: Transformer) => unknown;
@@ -690,8 +692,8 @@ export interface Theme {
 // @public (undocumented)
 export interface ThemeConfig {
     colorBlindnessMode?: ColorBlindnessMode;
+    dark?: boolean;
     overrides?: ThemeDefinition;
-    variant?: ThemeVariant;
 }
 
 // Warning: (ae-missing-release-tag) "ThemeDefinition" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -774,15 +776,13 @@ export class ThemeImpl implements Theme {
     // (undocumented)
     get config(): ThemeConfig;
     // (undocumented)
-    dark: () => ThemeImpl;
+    get dark(): boolean;
     // (undocumented)
     get definition(): ThemeDefinition;
     // (undocumented)
     flow: (markConfig?: MarkConfig) => Flow;
     // (undocumented)
     gridLines: () => GridLines;
-    // (undocumented)
-    light: () => ThemeImpl;
     // (undocumented)
     line: (markConfig?: MarkConfig) => Line;
     // (undocumented)
@@ -810,7 +810,11 @@ export class ThemeImpl implements Theme {
     // (undocumented)
     text: (markConfig?: MarkConfig) => Text;
     // (undocumented)
+    toDark: () => ThemeImpl;
+    // (undocumented)
     toJSON: (config?: ExportConfig) => ThemeSpec;
+    // (undocumented)
+    toLight: () => ThemeImpl;
     // (undocumented)
     tooltip: () => Tooltip;
     // (undocumented)

--- a/packages/core/src/Theme.ts
+++ b/packages/core/src/Theme.ts
@@ -70,7 +70,7 @@ import type {
 import { ThemeVariant } from './types/index.js'
 
 const defaultConfig = {
-	variant: ThemeVariant.Light,
+	dark: false,
 	colorBlindnessMode: ColorBlindnessMode.None,
 	overrides: {},
 }
@@ -92,7 +92,7 @@ export class Theme implements ITheme {
 	public constructor(spec: ThemeSpec, config?: ThemeConfig) {
 		const conf = merge({}, defaultConfig, config)
 		this._schemeCache = {}
-		const scheme = createScheme(spec, conf.variant, conf.colorBlindnessMode)
+		const scheme = createScheme(spec, conf.dark, conf.colorBlindnessMode)
 		this._scheme = scheme
 		this._spec = applyScheme(spec)
 		this._params = applyParams(this._spec)
@@ -109,16 +109,16 @@ export class Theme implements ITheme {
 		const overlayConfig = merge({}, this._config, config)
 		return new Theme(overlaySpec, overlayConfig)
 	}
-	public light = (): Theme => {
+	public toLight = (): Theme => {
 		return this.clone(this._spec, {
 			...this._config,
-			variant: ThemeVariant.Light,
+			dark: false,
 		})
 	}
-	public dark = (): Theme => {
+	public toDark = (): Theme => {
 		return this.clone(this._spec, {
 			...this._config,
-			variant: ThemeVariant.Dark,
+			dark: true,
 		})
 	}
 	public colorBlindness = (mode: ColorBlindnessMode): Theme => {
@@ -139,8 +139,11 @@ export class Theme implements ITheme {
 	public get name(): string {
 		return this._spec.name!
 	}
+	public get dark(): boolean {
+		return this._config.dark!
+	}
 	public get variant(): ThemeVariant {
-		return this._config.variant!
+		return this._config.dark ? ThemeVariant.Dark : ThemeVariant.Light
 	}
 	public get spec(): ThemeSpec {
 		return this._spec
@@ -305,7 +308,7 @@ export class Theme implements ITheme {
 		if (!this._schemeCache[size]) {
 			this._schemeCache[size] = createScheme(
 				this._spec,
-				this._config.variant,
+				this._config.dark,
 				this._config.colorBlindnessMode,
 				size,
 				size,

--- a/packages/core/src/__tests__/loader.spec.ts
+++ b/packages/core/src/__tests__/loader.spec.ts
@@ -12,7 +12,8 @@ describe('load', () => {
 	test('zero-config load (light theme)', () => {
 		const theme = load()
 		expect(theme.name).toBe('Default')
-		expect(theme.variant).toBe('light')
+		expect(theme.variant).toBe(ThemeVariant.Light)
+		expect(theme.dark).toBe(false)
 		expect(theme.chart().backgroundColor().hex()).toBe('none')
 		expect(theme.arc().stroke().hex()).toBe(STROKE_CSS)
 		expect(theme.text().fill().hex()).toBe('#303030')
@@ -20,10 +21,11 @@ describe('load', () => {
 
 	test('load dark theme', () => {
 		const theme = load({
-			variant: ThemeVariant.Dark,
+			dark: true,
 		})
 		expect(theme.name).toBe('Default')
-		expect(theme.variant).toBe('dark')
+		expect(theme.variant).toBe(ThemeVariant.Dark)
+		expect(theme.dark).toBe(true)
 		expect(theme.chart().backgroundColor().hex()).toBe('none')
 		expect(theme.arc().stroke().hex()).toBe('#323232')
 		expect(theme.text().fill().hex()).toBe('#e2e2e2')

--- a/packages/core/src/extensions/office.ts
+++ b/packages/core/src/extensions/office.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import type { Theme, Transformer } from '../types/index.js'
-import { ThemeVariant } from '../types/index.js'
 
 export type OfficeTheme = {
 	dark1: string
@@ -27,23 +26,19 @@ export type OfficeTheme = {
 export const office: Transformer<OfficeTheme> = (theme: Theme) => {
 	const nominal = theme.scales().nominal().toArray()
 	return {
-		dark1:
-			theme.variant === ThemeVariant.Dark
-				? theme.application().background().hex()
-				: theme.text().fill().hex(),
+		dark1: theme.dark
+			? theme.application().background().hex()
+			: theme.text().fill().hex(),
 
-		light1:
-			theme.variant === ThemeVariant.Dark
-				? theme.text().fill().hex()
-				: theme.application().background().hex(),
-		dark2:
-			theme.variant === ThemeVariant.Dark
-				? theme.plotArea().fill().hex()
-				: theme.application().accent().hex(),
-		light2:
-			theme.variant === ThemeVariant.Dark
-				? theme.application().accent().hex()
-				: theme.plotArea().fill().hex(),
+		light1: theme.dark
+			? theme.text().fill().hex()
+			: theme.application().background().hex(),
+		dark2: theme.dark
+			? theme.plotArea().fill().hex()
+			: theme.application().accent().hex(),
+		light2: theme.dark
+			? theme.application().accent().hex()
+			: theme.plotArea().fill().hex(),
 		accent1: nominal[0] as string,
 		accent2: nominal[1] as string,
 		accent3: nominal[2] as string,

--- a/packages/core/src/scheme.ts
+++ b/packages/core/src/scheme.ts
@@ -9,7 +9,6 @@ import set from 'lodash-es/set.js'
 
 import defaults from './themes/defaults.js'
 import type { SVGSpec, ThemeDefinition, ThemeSpec } from './types/index.js'
-import { ThemeVariant } from './types/index.js'
 
 // these are static default settings for the marks that are not derived from the computed scheme
 const DEFAULT_NOMINAL_ITEMS = 10
@@ -46,18 +45,13 @@ export function applyParams(spec: ThemeSpec): Params {
  */
 export function createScheme(
 	spec: ThemeSpec,
-	variant?: ThemeVariant,
+	dark = false,
 	colorBlindnessMode?: ColorBlindnessMode,
 	nominalItemCount: number = DEFAULT_NOMINAL_ITEMS,
 	sequentialItemCount: number = DEFAULT_SEQUENTIAL_ITEMS,
 ): Scheme {
 	const params = applyParams(spec)
-	const scheme = getScheme(
-		params,
-		nominalItemCount,
-		sequentialItemCount,
-		variant === undefined ? true : variant === ThemeVariant.Light,
-	)
+	const scheme = getScheme(params, nominalItemCount, sequentialItemCount, !dark)
 	return colorBlindness(scheme, colorBlindnessMode)
 }
 

--- a/packages/core/src/types/Theme.ts
+++ b/packages/core/src/types/Theme.ts
@@ -260,6 +260,7 @@ export type ChromeFunction<T> = () => T
  */
 export interface Theme {
 	name: string
+	dark: boolean
 	variant: ThemeVariant
 	params: Params
 	scheme: Scheme
@@ -295,11 +296,11 @@ export interface Theme {
 	/**
 	 * Return the light version of this Theme
 	 */
-	light: () => Theme
+	toLight: () => Theme
 	/**
 	 * Return the dark version of this Theme
 	 */
-	dark: () => Theme
+	toDark: () => Theme
 	/**
 	 * Return a color blindness-simulating copy of the theme
 	 */

--- a/packages/core/src/types/ThemeConfig.ts
+++ b/packages/core/src/types/ThemeConfig.ts
@@ -4,7 +4,6 @@
  */
 import type { ColorBlindnessMode } from '@thematic/color'
 
-import type { ThemeVariant } from './enums.js'
 import type { ThemeDefinition } from './ThemeDefinition.js'
 
 export interface ThemeConfig {
@@ -12,7 +11,7 @@ export interface ThemeConfig {
 	 * Set the color variant of the theme using one of the supported enum values.
 	 * If none supplied, loads the light version.
 	 */
-	variant?: ThemeVariant
+	dark?: boolean
 	/**
 	 * Set the simulated color blindness mode to use for this theme instance.
 	 */

--- a/packages/fluent/docs/fluent.api.md
+++ b/packages/fluent/docs/fluent.api.md
@@ -174,7 +174,7 @@ export interface ThematicFluentProviderProps {
 // Warning: (ae-missing-release-tag) "useThematicFluent" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-export function useThematicFluent(): FluentTheme;
+export function useThematicFluent(dark?: boolean): FluentTheme;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/fluent/src/FluentTheme.ts
+++ b/packages/fluent/src/FluentTheme.ts
@@ -5,7 +5,7 @@
 import type { Theme as IFluentTheme } from '@fluentui/react'
 import { createTheme } from '@fluentui/react'
 import type { Theme as IThematicTheme } from '@thematic/core'
-import { ThemeImpl, ThemeVariant } from '@thematic/core'
+import { ThemeImpl } from '@thematic/core'
 
 import { themeJson } from './theme/index.js'
 import type { FluentTheme as IThematicFluentTheme } from './types.js'
@@ -23,7 +23,7 @@ export class FluentTheme extends ThemeImpl implements IThematicFluentTheme {
 		this._tTheme = theme
 		this._fTheme = createTheme({
 			palette: themeJson(theme),
-			isInverted: theme.variant === ThemeVariant.Dark,
+			isInverted: theme.dark,
 		})
 	}
 	toThematic(): IThematicTheme {

--- a/packages/fluent/src/provider/useThematicFluent.ts
+++ b/packages/fluent/src/provider/useThematicFluent.ts
@@ -4,12 +4,17 @@
  */
 import { useContext } from 'react'
 
-import type { FluentTheme } from '../types.js'
+import { FluentTheme } from '../FluentTheme.js'
+import type { FluentTheme as IFluentTheme } from '../types.js'
 import { ThematicFluentContext } from './ThematicFluentContext.js'
 
 /**
  * Hook to retrieve the thematic theme directly.
  */
-export function useThematicFluent(): FluentTheme {
-	return useContext(ThematicFluentContext)
+export function useThematicFluent(dark?: boolean): IFluentTheme {
+	const theme = useContext(ThematicFluentContext)
+	if (dark) {
+		return new FluentTheme(theme.toDark())
+	}
+	return theme
 }

--- a/packages/fluent/src/theme/themeJson.ts
+++ b/packages/fluent/src/theme/themeJson.ts
@@ -8,7 +8,6 @@ import {
 	themeRulesStandardCreator,
 } from '@fluentui/react'
 import type { Theme } from '@thematic/core'
-import { ThemeVariant } from '@thematic/core'
 
 import { correctShades } from './shades.js'
 
@@ -55,7 +54,7 @@ const fluentJson = (colors: ThemeInputColors, inverted = false): any => {
  * @returns
  */
 export const themeJson = (theme: Theme): Record<string, string> => {
-	const inverted = theme.variant === ThemeVariant.Dark
+	const inverted = theme.dark
 	const colors: ThemeInputColors = {
 		primaryColor: theme.application().accent().hex(),
 		foregroundColor: theme.application().foreground().hex(),

--- a/packages/react/docs/react.api.md
+++ b/packages/react/docs/react.api.md
@@ -56,7 +56,7 @@ export interface ThematicProviderProps {
 // Warning: (ae-missing-release-tag) "useThematic" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-export function useThematic(): Theme;
+export function useThematic(dark?: boolean): Theme;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react/src/useThematic.ts
+++ b/packages/react/src/useThematic.ts
@@ -10,6 +10,7 @@ import { ThematicContext } from './ThematicContext.js'
 /**
  * Hook to retrieve the thematic theme directly.
  */
-export function useThematic(): Theme {
-	return useContext(ThematicContext)
+export function useThematic(dark?: boolean): Theme {
+	const theme = useContext(ThematicContext)
+	return dark ? theme.toDark() : theme
 }

--- a/packages/webapp/src/state/theme.ts
+++ b/packages/webapp/src/state/theme.ts
@@ -5,12 +5,7 @@
 import type { Params } from '@thematic/color'
 import { ColorBlindnessMode, defaultParams } from '@thematic/color'
 import type { Theme, ThemeListing } from '@thematic/core'
-import {
-	defaultThemes,
-	loadById,
-	loadFromSpec,
-	ThemeVariant,
-} from '@thematic/core'
+import { defaultThemes, loadById, loadFromSpec } from '@thematic/core'
 import { useCallback } from 'react'
 import {
 	atom,
@@ -83,7 +78,7 @@ const themeState = selector<Theme>({
 	dangerouslyAllowMutability: true,
 	get: ({ get }) => {
 		const info = get(themeInfoState)
-		const darkMode = get(darkModeState)
+		const dark = get(darkModeState)
 		const params = get(paramsState)
 		const colorBlindnessMode = get(colorBlindnessModeState)
 		return loadFromSpec(
@@ -92,7 +87,7 @@ const themeState = selector<Theme>({
 				params,
 			},
 			{
-				variant: darkMode ? ThemeVariant.Dark : ThemeVariant.Light,
+				dark,
 				colorBlindnessMode,
 			},
 		)


### PR DESCRIPTION
- Adds a `dark` prop to config to replace the more complex variant logic
- Retains `variant` getter for backcompat, but it's driven by the dark boolean
- Adds optional `dark` param to context hooks to simplify forcing a variant